### PR TITLE
Use `for_each` to make the configuration more DRY

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,8 +27,8 @@ module "landing_page_prod" {
 
   name = "${local.name}-prod-landing-page"
 
-  vpc_cidr_block = "10.0.0.0/16"
-  public_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  vpc_cidr_block            = "10.0.0.0/16"
+  public_subnet_cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 
   postgres_dbname   = var.landing_page_prod_postgres_dbname
   postgres_username = var.landing_page_prod_postgres_username

--- a/terraform/modules/landing-page/rds.tf
+++ b/terraform/modules/landing-page/rds.tf
@@ -23,5 +23,5 @@ resource "aws_db_instance" "this" {
 
 resource "aws_db_subnet_group" "this" {
   name       = "${var.name}-rds-subnet-group"
-  subnet_ids = [aws_subnet.a.id, aws_subnet.b.id, aws_subnet.c.id]
+  subnet_ids = values(aws_subnet.public)[*].id
 }

--- a/terraform/modules/landing-page/variables.tf
+++ b/terraform/modules/landing-page/variables.tf
@@ -7,7 +7,7 @@ variable "vpc_cidr_block" {
   type = string
 }
 
-variable "public_subnets" {
+variable "public_subnet_cidr_blocks" {
   type = list(string)
 }
 


### PR DESCRIPTION
Had to move the resources manually in the state, to avoid deletion and
recreation:
```
terraform state mv module.landing_page_prod.aws_route_table_association.a 'module.landing_page_prod.aws_route_table_association.this["eu-central-1a"]'
terraform state mv module.landing_page_prod.aws_route_table_association.b 'module.landing_page_prod.aws_route_table_association.this["eu-central-1b"]'
terraform state mv module.landing_page_prod.aws_route_table_association.c 'module.landing_page_prod.aws_route_table_association.this["eu-central-1c"]'
terraform state mv module.landing_page_prod.aws_subnet.a 'module.landing_page_prod.aws_subnet.public["eu-central-1a"]'
terraform state mv module.landing_page_prod.aws_subnet.b 'module.landing_page_prod.aws_subnet.public["eu-central-1b"]'
terraform state mv module.landing_page_prod.aws_subnet.c 'module.landing_page_prod.aws_subnet.public["eu-central-1c"]'
```
