### PR TITLE
Remove unused `aws_ses_configuration_set.this`

### DIFF
--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -5,20 +5,3 @@ resource "aws_ses_domain_identity" "apilytics_io" {
 resource "aws_ses_domain_dkim" "apilytics_io" {
   domain = aws_ses_domain_identity.apilytics_io.domain
 }
-
-resource "aws_ses_configuration_set" "this" {
-  name = "${local.name}-ses-config"
-}
-
-resource "aws_ses_event_destination" "this" {
-  name                   = "${local.name}-ses-destination"
-  configuration_set_name = aws_ses_configuration_set.this.name
-  matching_types         = ["bounce", "complaint", "reject"]
-  enabled                = true
-
-  cloudwatch_destination {
-    default_value  = "default"
-    dimension_name = "dimension"
-    value_source   = "emailHeader"
-  }
-}


### PR DESCRIPTION
They should be used by specifying a special `X-SES-CONFIGURATION-SET`
header when sending email, they don't do anything for us.
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets-in-email.html
