### PR TITLE
Remove SNS email alerts for SES bounces and complaints

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,8 +19,7 @@ terraform {
 // The IAM user that the repo is using has been created manually outside of Terraform.
 
 locals {
-  name        = "apilytics"
-  alert_email = "alert@apilytics.io"
+  name = "apilytics"
 }
 
 module "landing_page_prod" {

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -5,12 +5,3 @@ resource "aws_ses_domain_identity" "apilytics_io" {
 resource "aws_ses_domain_dkim" "apilytics_io" {
   domain = aws_ses_domain_identity.apilytics_io.domain
 }
-
-resource "aws_ses_identity_notification_topic" "apilytics_io" {
-  for_each = toset(["Bounce", "Complaint"])
-
-  topic_arn                = aws_sns_topic.ses_bounces.arn
-  notification_type        = each.value
-  identity                 = aws_ses_domain_identity.apilytics_io.domain
-  include_original_headers = true
-}

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -1,9 +1,0 @@
-resource "aws_sns_topic" "ses_bounces" {
-  name = "${local.name}-ses-bounces"
-}
-
-resource "aws_sns_topic_subscription" "ses_bounces" {
-  endpoint  = local.alert_email
-  protocol  = "email"
-  topic_arn = aws_sns_topic.ses_bounces.arn
-}


### PR DESCRIPTION
They are not needed since "email feedback forwarding" is already enabled
by default for the SES domain and it accomplishes exactly the same
thing.

More info:
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity-using-notifications-email.html