### PR TITLE
Fix `rev-parse HEAD^@` not working in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
         run: terraform init
 
       - name: "Set TFPLAN variable"
-        run: echo "TFPLAN=$(git rev-parse HEAD^@ | tail -1).tfplan" >> $GITHUB_ENV
+        run: echo "TFPLAN=$(git cat-file -p HEAD | grep '^parent' | tail -1 | cut -d ' ' -f 2).tfplan" >> $GITHUB_ENV
 
       - name: "Fetch the stored plan from S3"
         # No need to delete the plan file from S3. Our CI workflow will anyways leave lots of


### PR DESCRIPTION
`actions/checkout` only fetches the last commit by default, so we have
to get the parent's hash from the HEAD commit directly.
