### PR TITLE
Remove "landing page" from all identifiers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,6 @@ jobs:
       - name: "Terraform apply"
         run: terraform apply -auto-approve -input=false "$TFPLAN"
         env:
-          TF_VAR_landing_page_prod_postgres_dbname: ${{ secrets.TF_VAR_landing_page_prod_postgres_dbname }}
-          TF_VAR_landing_page_prod_postgres_username: ${{ secrets.TF_VAR_landing_page_prod_postgres_username }}
-          TF_VAR_landing_page_prod_postgres_password: ${{ secrets.TF_VAR_landing_page_prod_postgres_password }}
+          TF_VAR_prod_postgres_dbname: ${{ secrets.TF_VAR_prod_postgres_dbname }}
+          TF_VAR_prod_postgres_username: ${{ secrets.TF_VAR_prod_postgres_username }}
+          TF_VAR_prod_postgres_password: ${{ secrets.TF_VAR_prod_postgres_password }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         id: plan
         run: terraform plan -no-color -input=false -out="$TFPLAN"
         env:
-          TF_VAR_landing_page_prod_postgres_dbname: ${{ secrets.TF_VAR_landing_page_prod_postgres_dbname }}
-          TF_VAR_landing_page_prod_postgres_username: ${{ secrets.TF_VAR_landing_page_prod_postgres_username }}
-          TF_VAR_landing_page_prod_postgres_password: ${{ secrets.TF_VAR_landing_page_prod_postgres_password }}
+          TF_VAR_prod_postgres_dbname: ${{ secrets.TF_VAR_prod_postgres_dbname }}
+          TF_VAR_prod_postgres_username: ${{ secrets.TF_VAR_prod_postgres_username }}
+          TF_VAR_prod_postgres_password: ${{ secrets.TF_VAR_prod_postgres_password }}
 
       - name: "Store the generated plan in S3"
         run: aws s3 mv "$TFPLAN" s3://apilytics-terraform-state/plans/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,12 +21,12 @@ locals {
 module "apilytics_prod" {
   source = "./modules/apilytics"
 
-  name = "${local.name}-prod-landing-page"
+  name = "${local.name}-prod"
 
   vpc_cidr_block            = "10.0.0.0/16"
   public_subnet_cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 
-  postgres_dbname   = var.landing_page_prod_postgres_dbname
-  postgres_username = var.landing_page_prod_postgres_username
-  postgres_password = var.landing_page_prod_postgres_password
+  postgres_dbname   = var.prod_postgres_dbname
+  postgres_username = var.prod_postgres_username
+  postgres_password = var.prod_postgres_password
 }

--- a/terraform/modules/apilytics/rds.tf
+++ b/terraform/modules/apilytics/rds.tf
@@ -1,5 +1,5 @@
 resource "aws_db_instance" "this" {
-  identifier            = "apilytics-prod-rds"
+  identifier            = "${var.name}-rds"
   name                  = var.postgres_dbname
   engine                = "postgres"
   engine_version        = "12.8"
@@ -15,7 +15,7 @@ resource "aws_db_instance" "this" {
   vpc_security_group_ids = [aws_security_group.this.id]
   publicly_accessible    = true
 
-  final_snapshot_identifier = "apilytics-prod-final-snapshot"
+  final_snapshot_identifier = "${var.name}-final-snapshot"
   backup_window             = "03:00-03:30"
   maintenance_window        = "Mon:03:30-Mon:04:00"
   backup_retention_period   = 14
@@ -26,4 +26,8 @@ resource "aws_db_instance" "this" {
 resource "aws_db_subnet_group" "this" {
   name       = "${var.name}-rds-subnet-group"
   subnet_ids = values(aws_subnet.public)[*].id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform/modules/apilytics/vpc.tf
+++ b/terraform/modules/apilytics/vpc.tf
@@ -72,4 +72,8 @@ resource "aws_security_group" "this" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,14 +1,14 @@
-variable "landing_page_prod_postgres_dbname" {
+variable "prod_postgres_dbname" {
   type      = string
   sensitive = true
 }
 
-variable "landing_page_prod_postgres_username" {
+variable "prod_postgres_username" {
   type      = string
   sensitive = true
 }
 
-variable "landing_page_prod_postgres_password" {
+variable "prod_postgres_password" {
   type      = string
   sensitive = true
 }


### PR DESCRIPTION
Add `create_before_destroy` lifecyle rule to all resources that need to
be replaced because of this.

Luckily the identifier of the recently created new RDS db is already
correct.
