### PR TITLE
Revert renaming of RDS subnet group

### DIFF
--- a/terraform/modules/apilytics/rds.tf
+++ b/terraform/modules/apilytics/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "this" {
 }
 
 resource "aws_db_subnet_group" "this" {
-  name       = "${var.name}-rds-subnet-group"
+  name       = "${var.name}-landing-page-rds-subnet-group"
   subnet_ids = values(aws_subnet.public)[*].id
 
   lifecycle {


### PR DESCRIPTION
It's not possible to change an RDS instance's subnet groups into a group
that's in the same VPC.

Fixes this deployment:
https://github.com/blomqma/apilytics-infra/runs/4790606950