### PR TITLE
Fix deployment manually, remove lifecycle rule from RDS subnet group

### DIFF
--- a/terraform/modules/apilytics/rds.tf
+++ b/terraform/modules/apilytics/rds.tf
@@ -24,10 +24,6 @@ resource "aws_db_instance" "this" {
 }
 
 resource "aws_db_subnet_group" "this" {
-  name       = "${var.name}-landing-page-rds-subnet-group"
+  name       = "${var.name}-landing-page-rds-subnet-group" # Cannot rename this trivially.
   subnet_ids = values(aws_subnet.public)[*].id
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }


### PR DESCRIPTION
Ran these locally:
```
terraform state rm module.apilytics_prod.aws_db_subnet_group.this
terraform import module.apilytics_prod.aws_db_subnet_group.this apilytics-prod-landing-page-rds-subnet-group
```
