### PR TITLE
Split commit checking into a separate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,25 @@ defaults:
     working-directory: terraform
 
 jobs:
-  plan-infra:
-    name: "Plan Infra"
+  commits:
+    name: "Commits"
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout code (pre merge)"
+      - name: "Checkout code"
         uses: actions/checkout@v2
         with:
-          # Checkout the current commit instead of the commit that would get
-          # made when the PR would be merged, since we want to validate that
-          # the branch doesn't contain any merge commits and is rebased correctly.
-          # We also fetch all the objects here so that we can do the comparisons.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Check commits of the PR branch"
         run: ../.github/check_commits.sh
 
-      - name: "Checkout code (post merge)"
+  plan-infra:
+    name: "Plan Infra"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
         uses: actions/checkout@v2
 
       - name: "Configure AWS credentials"


### PR DESCRIPTION
Allows one to still see if the other parts of the pipeline pass, before
rebasing onto latest master.

Also, don't check commits if CI pipeline is re-ran after PR is merged
