### PR TITLE
Check commits against the PRs base branch instead of repo default

### DIFF
--- a/.github/check_commits.sh
+++ b/.github/check_commits.sh
@@ -5,7 +5,12 @@
 # on top of the latest default branch.
 # More details: https://stackoverflow.com/q/64435110/9835872
 
-head=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+if [ -n "$GITHUB_BASE_REF" ]; then
+    head="$GITHUB_BASE_REF"
+else
+    head="$(git remote show origin | awk '/HEAD branch/ {print $NF}')"
+fi
+
 current="$(git rev-parse HEAD)"
 
 if ! git merge-base --is-ancestor "origin/${head}" "$current"; then


### PR DESCRIPTION
These might not always be the same if one is targeting e.g. a longish
living development branch instead of master.
