### PR TITLE
Double the amount of available DB connections

### DIFF
--- a/terraform/modules/apilytics/rds.tf
+++ b/terraform/modules/apilytics/rds.tf
@@ -12,6 +12,7 @@ resource "aws_db_instance" "this" {
   password              = var.postgres_password
 
   db_subnet_group_name   = aws_db_subnet_group.this.name
+  parameter_group_name   = aws_db_parameter_group.this.name
   vpc_security_group_ids = [aws_security_group.this.id]
   publicly_accessible    = true
 
@@ -26,4 +27,15 @@ resource "aws_db_instance" "this" {
 resource "aws_db_subnet_group" "this" {
   name       = "${var.name}-landing-page-rds-subnet-group" # Cannot rename this trivially.
   subnet_ids = values(aws_subnet.public)[*].id
+}
+
+resource "aws_db_parameter_group" "this" {
+  name   = "${var.name}-parameter-group-pg12"
+  family = "postgres12"
+
+  parameter {
+    name         = "max_connections"
+    value        = 164 # Default for the instance class is 82.
+    apply_method = "pending-reboot"
+  }
 }


### PR DESCRIPTION
Attemps to fix these Prisma production errors:
```
ERROR	PrismaClientInitializationError: Error querying the database: db
error: FATAL: sorry, too many clients already

ERROR	PrismaClientInitializationError: Error querying the database: db
error: FATAL: remaining connection slots are reserved for
non-replication superuser connections
```
