### PR TITLE
Remove RDS deletion protection

### DIFF
--- a/terraform/modules/apilytics/rds.tf
+++ b/terraform/modules/apilytics/rds.tf
@@ -21,7 +21,7 @@ resource "aws_db_instance" "this" {
   maintenance_window        = "Mon:03:30-Mon:04:00"
   backup_retention_period   = 14
 
-  deletion_protection = true
+  deletion_protection = false
 }
 
 resource "aws_db_subnet_group" "this" {


### PR DESCRIPTION
We will delete the database, since we migrated to Digital Ocean because
of its built-in connection pool.
