### PR TITLE
Fix AWS ELB health checks not being able to reach running container

### DIFF
--- a/terraform/modules/geoip/ec2.tf
+++ b/terraform/modules/geoip/ec2.tf
@@ -3,7 +3,7 @@ resource "aws_launch_configuration" "this" {
   image_id             = data.aws_ssm_parameter.ecs_ami_id.value
   instance_type        = "t2.micro"
   user_data            = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.this.name} >> /etc/ecs/ecs.config"
-  security_groups      = [aws_security_group.this.id]
+  security_groups      = [aws_security_group.instance.id]
   iam_instance_profile = aws_iam_instance_profile.ecs_instance.id
 
   lifecycle {

--- a/terraform/modules/geoip/elb.tf
+++ b/terraform/modules/geoip/elb.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "this" {
   name               = "${var.name}-alb"
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.this.id]
+  security_groups    = [aws_security_group.elb.id]
   subnets            = values(aws_subnet.public)[*].id
 }
 

--- a/terraform/modules/geoip/vpc.tf
+++ b/terraform/modules/geoip/vpc.tf
@@ -51,8 +51,8 @@ resource "aws_route_table_association" "this" {
   route_table_id = aws_route_table.this.id
 }
 
-resource "aws_security_group" "this" {
-  name   = "${var.name}-sg"
+resource "aws_security_group" "elb" {
+  name   = "${var.name}-elb-sg"
   vpc_id = aws_vpc.this.id
 
   ingress {
@@ -60,6 +60,29 @@ resource "aws_security_group" "this" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name   = "${var.name}-instance-sg"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port       = 0
+    to_port         = 65535
+    protocol        = "tcp"
+    security_groups = [aws_security_group.elb.id]
   }
 
   egress {


### PR DESCRIPTION
Fix from:
https://stackoverflow.com/a/47766675/9835872

We need to allow all TCP ports since our container is mapped to a random
host port.
