### PR TITLE
Fix geoip canary deployment failing from not having enough memory

### DIFF
--- a/terraform/modules/geoip/ecs.tf
+++ b/terraform/modules/geoip/ecs.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_task_definition" "this" {
         name : local.container_name,
         image : "${replace(aws_ecr_repository.this.repository_url, "https://", "")}:${data.external.latest_ecr_tag.result["tag"]}",
         cpu : data.aws_ec2_instance_type.this.default_vcpus * 1024 / 2,
-        memoryReservation : data.aws_ec2_instance_type.this.memory_size / 2,
+        memoryReservation : (data.aws_ec2_instance_type.this.memory_size - 64) / 2,
         portMappings : [
           {
             containerPort : 8000,


### PR DESCRIPTION
We need to leave some (in this case 64 MiB) of memory to the ECS agent
and other system processes:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/memory-management.html