### PR TITLE
Replace EC2 launch configurations with launch templates

### DIFF
--- a/terraform/modules/geoip/autoscaling.tf
+++ b/terraform/modules/geoip/autoscaling.tf
@@ -1,10 +1,14 @@
 resource "aws_autoscaling_group" "prod" {
-  name                 = "${var.name}-asg"
-  desired_capacity     = 1
-  min_size             = 1
-  max_size             = 2
-  launch_configuration = aws_launch_configuration.this.name
-  vpc_zone_identifier  = values(aws_subnet.public)[*].id
+  name                = "${var.name}-asg"
+  desired_capacity    = 1
+  min_size            = 1
+  max_size            = 2
+  vpc_zone_identifier = values(aws_subnet.public)[*].id
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
 
   tag {
     key                 = "Name"

--- a/terraform/modules/geoip/ec2.tf
+++ b/terraform/modules/geoip/ec2.tf
@@ -1,13 +1,12 @@
-resource "aws_launch_configuration" "this" {
-  name_prefix          = "${var.name}-lc"
-  image_id             = data.aws_ssm_parameter.ecs_ami_id.value
-  instance_type        = local.instance_type
-  user_data            = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.this.name} >> /etc/ecs/ecs.config"
-  security_groups      = [aws_security_group.instance.id]
-  iam_instance_profile = aws_iam_instance_profile.ecs_instance.id
+resource "aws_launch_template" "this" {
+  name                   = "${var.name}-lt"
+  image_id               = data.aws_ssm_parameter.ecs_ami_id.value
+  instance_type          = local.instance_type
+  user_data              = base64encode("#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.this.name} >> /etc/ecs/ecs.config")
+  vpc_security_group_ids = [aws_security_group.instance.id]
 
-  lifecycle {
-    create_before_destroy = true
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs_instance.arn
   }
 }
 


### PR DESCRIPTION
They are the recommended way:
> We strongly recommend that you do not use launch configurations. They
> do not provide full functionality for Amazon EC2 Auto Scaling or Amazon
> EC2. We provide information about launch configurations for customers
> who have not yet migrated from launch configurations to launch
> templates.
>
> https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html