### PR TITLE
Add email report cron job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,3 +42,4 @@ jobs:
         run: terraform apply -auto-approve -input=false "$TFPLAN"
         env:
           TF_VAR_geoip_prod_api_key: ${{ secrets.TF_VAR_geoip_prod_api_key }}
+          TF_VAR_internal_api_key: ${{ secrets.TF_VAR_internal_api_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         run: terraform plan -no-color -input=false -out="$TFPLAN"
         env:
           TF_VAR_geoip_prod_api_key: ${{ secrets.TF_VAR_geoip_prod_api_key }}
+          TF_VAR_internal_api_key: ${{ secrets.TF_VAR_internal_api_key }}
 
       - name: "Store the generated plan in S3"
         run: aws s3 mv "$TFPLAN" s3://apilytics-terraform-state/plans/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,8 +26,9 @@ locals {
 module "geoip_prod" {
   source = "./modules/geoip"
 
-  name           = "${local.name}-geoip-prod"
-  domain         = "geoip.apilytics.io"
-  api_key        = var.geoip_prod_api_key
-  vpc_cidr_block = "10.0.0.0/16"
+  name             = "${local.name}-geoip-prod"
+  domain           = "geoip.apilytics.io"
+  api_key          = var.geoip_prod_api_key
+  internal_api_key = var.internal_api_key
+  vpc_cidr_block   = "10.0.0.0/16"
 }

--- a/terraform/modules/geoip/ec2.tf
+++ b/terraform/modules/geoip/ec2.tf
@@ -2,8 +2,18 @@ resource "aws_launch_template" "this" {
   name                   = "${var.name}-lt"
   image_id               = data.aws_ssm_parameter.ecs_ami_id.value
   instance_type          = local.instance_type
-  user_data              = base64encode("#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.this.name} >> /etc/ecs/ecs.config")
   vpc_security_group_ids = [aws_security_group.instance.id]
+
+  user_data = base64encode(
+    <<EOF
+      #!/bin/bash
+      echo ECS_CLUSTER=${aws_ecs_cluster.this.name} >> /etc/ecs/ecs.config
+      sudo service cron start
+      echo "* 0-0 * * MON curl --request POST \
+        --url 'https://www.apilytics.io/api/origins/email-reports' \
+        --header 'X-API-Key: ${var.internal_api_key}'" | crontab
+    EOF
+  )
 
   iam_instance_profile {
     arn = aws_iam_instance_profile.ecs_instance.arn

--- a/terraform/modules/geoip/variables.tf
+++ b/terraform/modules/geoip/variables.tf
@@ -17,3 +17,9 @@ variable "api_key" {
 variable "vpc_cidr_block" {
   type = string
 }
+
+variable "internal_api_key" {
+  description = "API key that's used to call internal email APIs."
+  type        = string
+  sensitive   = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,9 @@ variable "geoip_prod_api_key" {
   type        = string
   sensitive   = true
 }
+
+variable "internal_api_key" {
+  description = "API key that's used to call internal email APIs."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
The job calls the email report API
with the internal API key as part of
the EC2 user data.